### PR TITLE
Support hypershift CLI v4.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,76 @@
 # cluster-template-charts
-Helm Charts for use with the
-[cluster-templates-operator](https://github.com/stolostron/cluster-templates-operator/).
+Helm Charts for use with the [cluster-templates-operator].
 Refer to the Operator's documentation for more information.
 
-To install a chart/create a cluster (and infra/iam):
+## Charts
+
+### hypershift-aws-template
+
+#### Prerequisites
+
+To use this template you must have:
+
+1. Met all the [Hypershift prerequisites].
+
+2. Hypershift installed on a Kubernetes/OpenShift cluster. This can be accomplished using one of the following methods:
+    - [Install Multicluster Engine Operator] (MCE) 2.5+ (preferred)
+    - [Install Hypershift Operator]
+
+    If using MCE, create the OIDC provider secret with the S3 bucket from the prior step. E.g.
+
+    ```shell
+    kubectl create secret generic hypershift-operator-oidc-provider-s3-credentials \
+      --from-file=credentials=$HOME/.aws/credentials \
+      --from-literal=bucket=<s3-bucket-name> \
+      --from-literal=region=<s3-bucket-region> \
+      --namespace local-cluster
+    ```
+
+3. Created the `cluster-provisioner` service account and RBAC policies in the current namespace.
+
+    ```shell
+    kubectl create -f k8s/cluster-provisioner.yaml
+    ```
+
+4. Generated a Role ARN for use with the hypershift CLI. E.g.
+
+    ```shell
+    hypershift create iam cli-role \
+      --aws-creds "$HOME/.aws/credentials" \
+      --name "$USER-hypershift-cli-role" \
+      --additional-tags="expirationDate=$(date -d '1 year' --iso=minutes --utc)"
+    ```
+
+5. Created the `hypershift` secret in the current namespace. E.g.
+
+    ```shell
+    kubectl create secret generic hypershift \
+      --from-file=aws-credentials=$HOME/.aws/credentials \
+      --from-file=pull-secret=<path-to-ocp-pull-secret>
+    ```
+
+#### Usage
+
+To create a cluster (and infra/iam):
 
 ```shell
-helm install --wait --wait-for-jobs --timeout 20m my-cluster <chart-dir>
+export VERSION="4.16.11"
+export BASE_DOMAIN=<route53-domain>
+export ROLE_ARN=<hypershift-cli-role-arn>
+
+helm install \
+  --wait \
+  --wait-for-jobs \
+  --timeout 20m \
+  --set "version=$VERSION,baseDomain=$BASE_DOMAIN,hypershiftRoleArn=$ROLE_ARN" \
+  "$USER-cluster" \
+  ./charts/hypershift-aws-template
 ```
 
-To uninstall a chart/destroy a cluster (and infra/iam):
+To destroy a cluster (and infra/iam):
 
 ```shell
-helm uninstall --timeout 20m my-cluster
+helm uninstall --timeout 20m "$USER-cluster"
 ```
 
 ## Releases
@@ -22,3 +80,8 @@ charts upon merge to the `main` branch.
 
 The chart repository is hosted with GitHub Pages and located at
 https://konflux-ci.dev/cluster-template-charts.
+
+[cluster-templates-operator]: https://github.com/stolostron/cluster-templates-operator/
+[Hypershift prerequisites]: https://hypershift-docs.netlify.app/getting-started#prerequisites
+[Install Multicluster Engine Operator]: https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#mce-install-intro
+[Install Hypershift Operator]: https://hypershift-docs.netlify.app/getting-started/#install-hypershift-operator

--- a/charts/hypershift-aws-template/Chart.yaml
+++ b/charts/hypershift-aws-template/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hypershift-aws-template/templates/_helpers.tpl
+++ b/charts/hypershift-aws-template/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{- define "credential-volumes" -}}
+- name: secret
+  secret:
+    secretName: "{{ .Values.secret }}"
+- name: sts
+  emptyDir: {}
+{{- end -}}
+
+{{- define "aws-sts-init-container" -}}
+- name: aws-sts
+  image: public.ecr.aws/aws-cli/aws-cli:2.17.41@sha256:76c484c1d90d4c798554b92427c42f7f33f5626e437ee120e9c90e63c35a886d
+  env:
+    - name: AWS_SHARED_CREDENTIALS_FILE
+      value: /secret/aws-credentials
+  volumeMounts:
+    - name: secret
+      mountPath: /secret
+    - name: sts
+      mountPath: /sts
+  command: ["/bin/sh"]
+  args:
+    - -ec
+    - |
+      aws sts get-session-token --output json > /sts/token.json
+      echo "STS token acquired successfully"
+{{- end -}}

--- a/charts/hypershift-aws-template/templates/create-cluster-job.yaml
+++ b/charts/hypershift-aws-template/templates/create-cluster-job.yaml
@@ -11,9 +11,18 @@ spec:
     spec:
       serviceAccountName: "{{ .Values.serviceAccount }}"
       restartPolicy: Never
+      volumes:
+        {{- include "credential-volumes" . | nindent 8 }}
+      initContainers:
+        {{- include "aws-sts-init-container" . | nindent 8 }}
       containers:
         - name: hypershift
           image: quay.io/hypershift/hypershift-operator:{{ .Values.hypershiftImageTag }}
+          volumeMounts:
+            - name: sts
+              mountPath: /sts
+            - name: secret
+              mountPath: /secret
           args:
             - create
             - cluster
@@ -24,10 +33,17 @@ spec:
             - "{{ .Release.Name | trunc -12 }}"
             - --namespace
             - "{{ .Release.Namespace }}"
-            - --secret-creds
-            - "{{ .Values.secret }}"
+            - --sts-creds
+            - /sts/token.json
+            - --role-arn
+            - "{{ .Values.hypershiftRoleArn }}"
+            - --pull-secret
+            - /secret/pull-secret
+            - --base-domain
+            - "{{ .Values.baseDomain }}"
             - --region
             - "{{ .Values.region }}"
+            - --multi-arch
             - --arch
             {{- if hasPrefix "m6g." .Values.instanceType }}
             - arm64

--- a/charts/hypershift-aws-template/templates/destroy-cluster-job.yaml
+++ b/charts/hypershift-aws-template/templates/destroy-cluster-job.yaml
@@ -16,9 +16,16 @@ spec:
     spec:
       serviceAccountName: "{{ .Values.serviceAccount }}"
       restartPolicy: Never
+      volumes:
+        {{- include "credential-volumes" . | nindent 8 }}
+      initContainers:
+        {{- include "aws-sts-init-container" . | nindent 8 }}
       containers:
         - name: hypershift
           image: quay.io/hypershift/hypershift-operator:{{ .Values.hypershiftImageTag }}
+          volumeMounts:
+            - name: sts
+              mountPath: /sts
           args:
             - destroy
             - cluster
@@ -29,8 +36,10 @@ spec:
             - "{{ .Release.Name | trunc -12 }}"
             - --namespace
             - "{{ .Release.Namespace }}"
-            - --secret-creds
-            - "{{ .Values.secret }}"
+            - --sts-creds
+            - /sts/token.json
+            - --role-arn
+            - "{{ .Values.hypershiftRoleArn }}"
             - --region
             - "{{ .Values.region }}"
             - --base-domain

--- a/charts/hypershift-aws-template/values.schema.json
+++ b/charts/hypershift-aws-template/values.schema.json
@@ -4,6 +4,7 @@
   "required": [
     "baseDomain",
     "hypershiftImageTag",
+    "hypershiftRoleArn",
     "instanceType",
     "nodePoolReplicas",
     "region",
@@ -13,12 +14,16 @@
   ],
   "properties": {
     "baseDomain": {
-      "description": "Base domain already configured in AWS Route53",
-      "type": "string"
+      "type": "string",
+      "description": "Base domain already configured in AWS Route53"
     },
     "hypershiftImageTag": {
-      "description": "Container image tag for the hypershift CLI",
-      "type": "string"
+      "type": "string",
+      "description": "Container image tag for the hypershift CLI"
+    },
+    "hypershiftRoleArn": {
+      "type": "string",
+      "description": "The ARN of the IAM role assumed by the STS credentials provided to the hypershift CLI"
     },
     "instanceType": {
       "type": "string",

--- a/charts/hypershift-aws-template/values.yaml
+++ b/charts/hypershift-aws-template/values.yaml
@@ -1,6 +1,6 @@
 # Default values for hypershift-aws-template.
 
-hypershiftImageTag: latest
+hypershiftImageTag: "4.16"
 
 instanceType: m5.large
 

--- a/k8s/cluster-provisioner.yaml
+++ b/k8s/cluster-provisioner.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-provisioner
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-provisioner
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedclusters
+  - nodepools
+  verbs:
+  - "*"
+- apiGroups:
+  - clustertemplate.openshift.io
+  resources:
+  - clustertemplateinstances
+  verbs:
+  - "*"
+- apiGroups:
+  - clustertemplate.openshift.io
+  resources:
+  - clustertemplates
+  verbs:
+  - get
+  - list
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-provisioner-rb
+subjects:
+- kind: ServiceAccount
+  name: cluster-provisioner
+roleRef:
+  kind: Role
+  name: cluster-provisioner
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
The default hypershift image tag is now set to `4.16` since `latest` has breaking changes.

The documentation has been overhauled with more detailed instructions.