### PR TITLE
Allow the user to specify the full hypershift image

### DIFF
--- a/charts/hypershift-aws-template/Chart.yaml
+++ b/charts/hypershift-aws-template/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hypershift-aws-template/templates/create-cluster-job.yaml
+++ b/charts/hypershift-aws-template/templates/create-cluster-job.yaml
@@ -17,12 +17,14 @@ spec:
         {{- include "aws-sts-init-container" . | nindent 8 }}
       containers:
         - name: hypershift
-          image: quay.io/hypershift/hypershift-operator:{{ .Values.hypershiftImageTag }}
+          image: "{{ .Values.hypershiftImage }}"
           volumeMounts:
             - name: sts
               mountPath: /sts
             - name: secret
               mountPath: /secret
+          command:
+            - hypershift
           args:
             - create
             - cluster

--- a/charts/hypershift-aws-template/templates/destroy-cluster-job.yaml
+++ b/charts/hypershift-aws-template/templates/destroy-cluster-job.yaml
@@ -22,10 +22,12 @@ spec:
         {{- include "aws-sts-init-container" . | nindent 8 }}
       containers:
         - name: hypershift
-          image: quay.io/hypershift/hypershift-operator:{{ .Values.hypershiftImageTag }}
+          image: "{{ .Values.hypershiftImage }}"
           volumeMounts:
             - name: sts
               mountPath: /sts
+          command:
+            - hypershift
           args:
             - destroy
             - cluster

--- a/charts/hypershift-aws-template/values.schema.json
+++ b/charts/hypershift-aws-template/values.schema.json
@@ -3,7 +3,7 @@
   "type": "object",
   "required": [
     "baseDomain",
-    "hypershiftImageTag",
+    "hypershiftImage",
     "hypershiftRoleArn",
     "instanceType",
     "nodePoolReplicas",
@@ -17,9 +17,9 @@
       "type": "string",
       "description": "Base domain already configured in AWS Route53"
     },
-    "hypershiftImageTag": {
+    "hypershiftImage": {
       "type": "string",
-      "description": "Container image tag for the hypershift CLI"
+      "description": "Container image for the hypershift CLI"
     },
     "hypershiftRoleArn": {
       "type": "string",

--- a/charts/hypershift-aws-template/values.yaml
+++ b/charts/hypershift-aws-template/values.yaml
@@ -1,6 +1,6 @@
 # Default values for hypershift-aws-template.
 
-hypershiftImageTag: "4.16"
+hypershiftImage: quay.io/hypershift/hypershift-operator:latest
 
 instanceType: m5.large
 


### PR DESCRIPTION
The default image is used by hypershift QE. It should be overwritten when used in a production setting but the value depends on how hypershift is installed (e.g. using `hypershift install` vs via the Multicluster Engine operator).