### PR TITLE
Fix errors when trying to release existing chart versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,3 +27,5 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          skip_existing: true


### PR DESCRIPTION
The release workflow should no longer error when changes are made to a chart and the version isn't bumped.