### PR TITLE
Render helm charts for checkov

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -22,12 +22,22 @@ jobs:
 
       - name: Run checkov
         uses: bridgecrewio/checkov-action@v12
+        id: checkov
         with:
           output_format: cli,sarif
           output_file_path: console,results.sarif
+          var_file: test/dummy-vars.yaml
+        env:
+          HELM_NAMESPACE: dummy-ns
         continue-on-error: true
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif
+
+      - name: Report failure
+        if: steps.checkov.outcome == 'failure'
+        run: |
+          echo "The checkov scan resulted in failure. See the output of the above step."
+          exit 1

--- a/charts/hypershift-aws-template/Chart.yaml
+++ b/charts/hypershift-aws-template/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hypershift-aws-template/templates/_helpers.tpl
+++ b/charts/hypershift-aws-template/templates/_helpers.tpl
@@ -6,9 +6,38 @@
   emptyDir: {}
 {{- end -}}
 
+{{- define "container-resources" -}}
+resources:
+  requests:
+    cpu: 100m
+    memory: 100Mi
+  limits:
+    cpu: 100m
+    memory: 100Mi
+{{- end -}}
+
+{{- define "container-security-context" -}}
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - NET_RAW
+      - ALL
+{{- end -}}
+
+{{- define "pod-security-context" -}}
+securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+{{- end -}}
+
 {{- define "aws-sts-init-container" -}}
 - name: aws-sts
   image: public.ecr.aws/aws-cli/aws-cli:2.17.41@sha256:76c484c1d90d4c798554b92427c42f7f33f5626e437ee120e9c90e63c35a886d
+  {{- include "container-resources" . | nindent 2 }}
+  {{- include "container-security-context" . | nindent 2 }}
   env:
     - name: AWS_SHARED_CREDENTIALS_FILE
       value: /opt/hypershift/secret/aws-credentials

--- a/charts/hypershift-aws-template/templates/create-cluster-job.yaml
+++ b/charts/hypershift-aws-template/templates/create-cluster-job.yaml
@@ -4,6 +4,10 @@ kind: Job
 metadata:
   name: create-cluster-{{ .Release.Name }}
   namespace: "{{ .Release.Namespace }}"
+  annotations:
+    checkov.io/skip-ckv-k8s-38: CKV_K8S_38=The hypershift image requires a service account token
+    checkov.io/skip-ckv-k8s-40: CKV_K8S_40=RunAsUser should not be set when using the anyuid SCC on OpenShift
+    checkov.io/skip-ckv2-k8s-6: CKV2_K8S_6=NetworkPolicies should be created by namespace admins
 spec:
   template:
     metadata:
@@ -11,6 +15,7 @@ spec:
     spec:
       serviceAccountName: "{{ .Values.serviceAccount }}"
       restartPolicy: Never
+      {{- include "pod-security-context" . | nindent 6 }}
       volumes:
         {{- include "credential-volumes" . | nindent 8 }}
         - name: config
@@ -21,6 +26,8 @@ spec:
       containers:
         - name: hypershift
           image: "{{ .Values.hypershiftImage }}"
+          {{- include "container-resources" . | nindent 10 }}
+          {{- include "container-security-context" . | nindent 10 }}
           volumeMounts:
             - name: sts
               mountPath: /opt/hypershift/sts

--- a/charts/hypershift-aws-template/templates/destroy-cluster-job.yaml
+++ b/charts/hypershift-aws-template/templates/destroy-cluster-job.yaml
@@ -9,6 +9,9 @@ metadata:
     helm.sh/hook-delete-policy: hook-succeeded
     argocd.argoproj.io/hook: PostDelete
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    checkov.io/skip-ckv-k8s-38: CKV_K8S_38=The hypershift image requires a service account token
+    checkov.io/skip-ckv-k8s-40: CKV_K8S_40=RunAsUser should not be set when using the anyuid SCC on OpenShift
+    checkov.io/skip-ckv2-k8s-6: CKV2_K8S_6=NetworkPolicies should be created by namespace admins
 spec:
   template:
     metadata:
@@ -16,6 +19,7 @@ spec:
     spec:
       serviceAccountName: "{{ .Values.serviceAccount }}"
       restartPolicy: Never
+      {{- include "pod-security-context" . | nindent 6 }}
       volumes:
         {{- include "credential-volumes" . | nindent 8 }}
       initContainers:
@@ -23,6 +27,8 @@ spec:
       containers:
         - name: hypershift
           image: "{{ .Values.hypershiftImage }}"
+          {{- include "container-resources" . | nindent 10 }}
+          {{- include "container-security-context" . | nindent 10 }}
           volumeMounts:
             - name: sts
               mountPath: /opt/hypershift/sts

--- a/k8s/cluster-provisioner.yaml
+++ b/k8s/cluster-provisioner.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: cluster-provisioner
   annotations:
-    checkov.io/skip-k8s-21: CKV_K8S_21=Example intended to be deployed to the current context's namespace
+    checkov.io/skip-ckv-k8s-21: CKV_K8S_21=Example intended to be deployed to the current context's namespace
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12,7 +12,7 @@ kind: Role
 metadata:
   name: cluster-provisioner
   annotations:
-    checkov.io/skip-k8s-21: CKV_K8S_21=Example intended to be deployed to the current context's namespace
+    checkov.io/skip-ckv-k8s-21: CKV_K8S_21=Example intended to be deployed to the current context's namespace
 rules:
 - apiGroups:
   - ""
@@ -53,7 +53,7 @@ kind: RoleBinding
 metadata:
   name: cluster-provisioner-rb
   annotations:
-    checkov.io/skip-k8s-21: CKV_K8S_21=Example intended to be deployed to the current context's namespace
+    checkov.io/skip-ckv-k8s-21: CKV_K8S_21=Example intended to be deployed to the current context's namespace
 subjects:
 - kind: ServiceAccount
   name: cluster-provisioner

--- a/test/dummy-vars.yaml
+++ b/test/dummy-vars.yaml
@@ -1,0 +1,6 @@
+---
+# Dummy values which will allow the charts to be rendered (e.g. for scanning w/checkov)
+baseDomain: dummy-domain
+hypershiftImage: quay.io/hypershift/hypershift-operator:dummy-tag@sha256:e35d4ccc9fc789c4e9255ab8109a12e4a5371a34c7d64687eb14cd749e2ae531
+hypershiftRoleArn: dummy-arn
+version: dummy-version


### PR DESCRIPTION
Checkov wasn't scanning the chart manifests because of missing required values. Fixes for the unearthed issues are included.