### PR TITLE
Disable job retries when creating hypershift clusters

### DIFF
--- a/charts/hypershift-aws-template/Chart.yaml
+++ b/charts/hypershift-aws-template/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hypershift-aws-template/templates/create-cluster-job.yaml
+++ b/charts/hypershift-aws-template/templates/create-cluster-job.yaml
@@ -9,6 +9,7 @@ metadata:
     checkov.io/skip-ckv-k8s-40: CKV_K8S_40=RunAsUser should not be set when using the anyuid SCC on OpenShift
     checkov.io/skip-ckv2-k8s-6: CKV2_K8S_6=NetworkPolicies should be created by namespace admins
 spec:
+  backoffLimit: 0
   template:
     metadata:
       name: create-cluster-{{ .Release.Name }}


### PR DESCRIPTION
The retries almost always fail because the HostedCluster cannot be recreated. They prolong the inevitable failure for the user and aren't providing much value.

Noticed while investigating KONFLUX-6267.