### PR TITLE
Deploy an optional pause pod

### DIFF
--- a/charts/hypershift-aws-template/Chart.yaml
+++ b/charts/hypershift-aws-template/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hypershift-aws-template/templates/pause-pod.yaml
+++ b/charts/hypershift-aws-template/templates/pause-pod.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.pausePod.enabled }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pause-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  priorityClassName: {{ .Values.pausePod.priorityClass }}
+  containers:
+    - name: pause
+      image: {{ .Values.pausePod.image }}
+      resources:
+        requests:
+          cpu: {{ .Values.pausePod.cpu }}
+          memory: {{ .Values.pausePod.memory }}
+{{- end }}

--- a/charts/hypershift-aws-template/values.schema.json
+++ b/charts/hypershift-aws-template/values.schema.json
@@ -18,6 +18,34 @@
       "type": "string",
       "description": "Base domain already configured in AWS Route53"
     },
+    "pausePod": {
+      "type": "object",
+      "description": "Pause pod settings (e.g. for over-provisioning)",
+      "required": [
+        "cpu",
+        "enabled",
+        "image",
+        "memory"
+      ],
+      "properties": {
+        "cpu": {
+          "type": "string",
+          "description": "CPU resources requested by the pause container"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Enables the pause pod"
+        },
+        "image": {
+          "type": "string",
+          "description": "Image used by the pause container"
+        },
+        "memory": {
+          "type": "string",
+          "description": "Memory resources requested by the pause container"
+        }
+      }
+    },
     "hypershiftImage": {
       "type": "string",
       "description": "Container image for the hypershift CLI"

--- a/charts/hypershift-aws-template/values.yaml
+++ b/charts/hypershift-aws-template/values.yaml
@@ -8,6 +8,15 @@ instanceType: m5.large
 
 nodePoolReplicas: 2
 
+pausePod:
+  enabled: false
+  priorityClass: pause-pod-priority
+  image: registry.access.redhat.com/ubi8/pause:8.10@sha256:70fe7710ec4a43b79e142252dbba898ecdfebd5cfb1140b52355db81882aee8c
+  # Sizing based on the baseline resource consumption for a control plane:
+  # https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/hosted_control_planes/preparing-to-deploy-hosted-control-planes#hcp-pod-limits_hcp-sizing-guidance
+  cpu: "5"
+  memory: 18Gi
+
 region: us-east-1
 
 # checkov:skip=CKV_SECRET_6:This is the name of a Secret, not its content


### PR DESCRIPTION
Pause pods are an effective way to over-provision the cluster and make autoscaling more responsive.