### PR TITLE
feat(fips): Add FIPS compliance option for aws Hypershift clusters

### DIFF
--- a/charts/hypershift-aws-template/templates/create-cluster-job.yaml
+++ b/charts/hypershift-aws-template/templates/create-cluster-job.yaml
@@ -48,6 +48,8 @@ spec:
             - "{{ .Release.Name | trunc -12 }}"
             - --namespace
             - "{{ .Release.Namespace }}"
+            - --fips
+            - "{{ .Values.fips }}"
             - --sts-creds
             - /opt/hypershift/sts/token.json
             - --role-arn

--- a/charts/hypershift-aws-template/values.yaml
+++ b/charts/hypershift-aws-template/values.yaml
@@ -25,3 +25,5 @@ secret: hypershift
 serviceAccount: cluster-provisioner
 
 timeout: 20m
+
+fips: false


### PR DESCRIPTION
Adds a new `fips` boolean flag to the chart to allow provisioning FIPS-compliant Hypershift clusters on AWS.

When `fips` is set to `true`, the `hypershift create cluster aws` command will be invoked with the `--fips` flag. This configures the hosted OpenShift cluster to operate in FIPS mode, ensuring:
- All cryptographic operations use FIPS 140-2 (or 140-3, if applicable) validated modules.
- The underlying RHCOS nodes are FIPS-enabled.
- Network communication utilizes FIPS-compliant protocols, specifically by setting `networkType: OVNKubernetes` and enabling IPSec.

This feature is crucial for environments requiring strict security and regulatory compliance.

Reference:
- Hypershift FIPS flag: https://github.com/openshift/hypershift/blob/9720e90964cf527422033550889835ee450ba46a/cmd/cluster/core/create.go#L88