### PR TITLE
Bump hypsershift-aws-template chart to v0.1.7

### DIFF
--- a/charts/hypershift-aws-template/Chart.yaml
+++ b/charts/hypershift-aws-template/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": false,
   "extends": [
     "config:recommended"
   ],


### PR DESCRIPTION
The renovate dependency dashboard is also disabled since it's unused.