### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
 
@@ -24,7 +24,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584  # v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -20,10 +20,10 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Run checkov
-        uses: bridgecrewio/checkov-action@v12
+        uses: bridgecrewio/checkov-action@9b70310bcd306d11740313070b940167d6b23085  # v12
         id: checkov
         with:
           output_format: cli,sarif
@@ -34,7 +34,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
         with:
           sarif_file: results.sarif
 

--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -16,7 +16,7 @@ jobs:
       yaml: ${{ steps.changed-files.outputs.any_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
         with:
           fetch-depth: 0
       - name: Check for changes
@@ -36,7 +36,7 @@ jobs:
     if: needs.check-changes.outputs.yaml == 'true'
     steps:
       - name: Clone the code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
 
       - name: Run yamllint
         uses: frenck/action-yamllint@34b4bbcaeabedcfefad6adea8c5bbc42af0e2d47  # v1

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
     "helmv3",
     "helm-values",
     "kubernetes",
-    "regex"
+    "regex",
+    "github-actions"
   ],
   "kubernetes": {
     "fileMatch": [


### PR DESCRIPTION
## Summary
- Pin GitHub Actions in workflows to full 40-character commit SHAs with inline version comments so Renovate can keep updating them.
- Leave org reusable `fullsend` workflow refs on `@main` unchanged where present.
- Enable the \`github-actions\` Renovate manager (it was excluded by \`enabledManagers\`)

## Test plan
- [ ] Workflows that use the pinned actions still pass CI
- [ ] YAML lint (if present) is clean for comment spacing before `#`

Made with [Cursor](https://cursor.com)